### PR TITLE
remove fsc-utils

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -14,7 +14,7 @@
                 {{ create_UDF_GET_CHAINHEAD() }}
             {% endset %}
             {% do run_query(sql) %}
-        {{- fsc_utils.create_udfs() -}}
+        {# {{- fsc_utils.create_udfs() -}} #}
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/models/streamline/poc/decoder/streamline__decoded_input_events.sql
+++ b/models/streamline/poc/decoder/streamline__decoded_input_events.sql
@@ -1,14 +1,5 @@
 {{ config (
     materialized = "view",
-    post_hook = fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_near_events',
-        target = "{{this.schema}}.{{this.identifier}}",
-        params ={ "external_table" :"DECODED_INPUT_EVENTS",
-        "sql_limit" :"500",
-        "producer_batch_size" :"50",
-        "worker_batch_size" :"10",
-        "sql_source" :"{{this.identifier}}" }
-    ),
 ) }}
 
 SELECT 

--- a/models/streamline/poc/decoder/streamline__decoded_output_events.sql
+++ b/models/streamline/poc/decoder/streamline__decoded_output_events.sql
@@ -1,14 +1,5 @@
 {{ config (
     materialized = "view",
-    post_hook = fsc_utils.if_data_call_function_v2(
-        func = 'streamline.udf_bulk_decode_near_events',
-        target = "{{this.schema}}.{{this.identifier}}",
-        params ={ "external_table" :"DECODED_INPUT_EVENTS",
-        "sql_limit" :"500",
-        "producer_batch_size" :"50",
-        "worker_batch_size" :"10",
-        "sql_source" :"{{this.identifier}}" }
-    ),
 ) }}
 
 SELECT 

--- a/packages.yml
+++ b/packages.yml
@@ -3,7 +3,5 @@ packages:
     version: 0.8.2
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: "v1.29.0"
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
- Removes `fsc_utils` package to prevent circular dependency when pulling in `near-models` to reuse gold layer transformations in `livequery gold UDTF's`

**Note**: This is just a temporary solution to circumvent the circular dependency and enable adhering to DRY principles while building out the `Near Gold UDTF's`